### PR TITLE
feat: add query test button

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,10 +1,15 @@
 // https://nuxt.com/docs/api/configuration/nuxt-config
+import { presetWind } from '@unocss/preset-wind'
+
 export default defineNuxtConfig({
   compatibilityDate: '2025-05-15',
   devtools: { enabled: true },
-  modules: ['@nuxt/eslint', 'nuxt-graphql-server'],
+  modules: ['@nuxt/eslint', 'nuxt-graphql-server', '@unocss/nuxt'],
   graphqlServer: {
     url: '/api/gql',
     schema: './server/api/schemas/*.gql',
-  }
+  },
+  unocss: {
+    presets: [presetWind()],
+  },
 })

--- a/package.json
+++ b/package.json
@@ -24,6 +24,8 @@
     "node": "24.3.0"
   },
   "devDependencies": {
-    "@as-integrations/h3": "^2.0.0"
+    "@as-integrations/h3": "^2.0.0",
+    "@unocss/nuxt": "^0.63.0",
+    "@unocss/preset-wind": "^0.63.0"
   }
 }

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed } from 'vue'
+import { ref } from 'vue'
 
 const query = `query {
   products {
@@ -10,24 +10,49 @@ const query = `query {
   }
 }`
 
-const { data, error } = await useFetch('/api/gql', {
-  method: 'POST',
-  body: { query }
-})
+const loading = ref(false)
+const result = ref(null)
+const error = ref(null)
 
-const products = computed(() => data.value?.data?.products ?? [])
+async function runQuery() {
+  loading.value = true
+  result.value = null
+  error.value = null
+  try {
+    result.value = await $fetch('/api/gql', {
+      method: 'POST',
+      body: { query }
+    })
+  } catch (err) {
+    error.value = err
+  } finally {
+    loading.value = false
+  }
+}
 </script>
 
 <template>
-  <main>
-    <h1>Products</h1>
-    <p v-if="error">Error: {{ error.message }}</p>
-    <ul v-else>
-      <li v-for="product in products" :key="product.id">
-        <h2>{{ product.name }}</h2>
-        <p>{{ product.description }}</p>
-        <p v-if="product.price">Price: {{ product.price }}</p>
-      </li>
-    </ul>
+  <main class="min-h-screen p-8 bg-[#f7f7f8] flex flex-col items-center">
+    <h1 class="text-xl mb-6">GraphQL Products</h1>
+    <button
+      class="bg-[#10a37f] text-white rounded-md px-6 py-3 text-base cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+      :disabled="loading"
+      @click="runQuery"
+    >
+      {{ loading ? 'Loading...' : 'Test Query' }}
+    </button>
+    <div
+      v-if="error"
+      class="w-full max-w-[40rem] mt-6 rounded-md px-6 py-4 bg-white shadow whitespace-pre-wrap border-l-4 border-red-500 text-red-700"
+    >
+      <pre>{{ error.message ?? error }}</pre>
+    </div>
+    <div
+      v-else-if="result"
+      class="w-full max-w-[40rem] mt-6 rounded-md px-6 py-4 bg-white shadow whitespace-pre-wrap"
+    >
+      <pre>{{ JSON.stringify(result, null, 2) }}</pre>
+    </div>
   </main>
 </template>
+


### PR DESCRIPTION
## Summary
- add Test Query button to run GraphQL product query on demand and display result or errors
- restyle page with chatGPT-like layout using UnoCSS Windi preset utilities

## Testing
- `pnpm exec eslint pages/index.vue` *(failed: command produced no output)*
- `pnpm build` *(fails: Cannot find module '@unocss/preset-wind')*

------
https://chatgpt.com/codex/tasks/task_b_689e3b98fe7883269d21b9a8936d3ae4